### PR TITLE
Add option aliasing support

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -90,7 +90,8 @@ flog_config_new(int argc, char *argv[]) {
     flog_config_set_version_flag(config, false);
     flog_config_set_help_flag(config, false);
 
-    poptContext context = poptGetContext(NULL, argc, (const char**) argv, options, 0);
+    poptContext context = poptGetContext("uk.co.fidgetbox.flog", argc, (const char**) argv, options, 0);
+    poptReadDefaultConfig(context, 0);
 
     int option;
     while ((option = poptGetNextOpt(context)) >= 0) {


### PR DESCRIPTION
Enable `libpopt`'s option aliasing support using default config paths (`/etc/popt` and `~/.popt`).

Implements: https://github.com/marcransome/flog/discussions/70#discussioncomment-4870518.