### PR TITLE
Update CodeQL configuration

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,6 +31,6 @@ jobs:
       run: |
         cmake -S . -B build
         cmake --build build
-        cp -r src/* /build/src/
+        cp -r src/* build/src/
     - name: Perform CodeQL analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Install dependencies
-      run: brew install pkg-config popt
+      run: brew install popt
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,15 +20,17 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
+    - name: Install dependencies
+      run: brew install popt
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
         languages: cpp
         queries: security-and-quality
-    - name: Install dependencies and build project
+    - name: Build sources
       run: |
-        brew install pkg-config popt
         cmake -S . -B build
         cmake --build build
+        cd src
     - name: Perform CodeQL analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Install dependencies
-      run: brew install popt
+      run: brew install pkg-config popt
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
@@ -31,6 +31,6 @@ jobs:
       run: |
         cmake -S . -B build
         cmake --build build
-        cd src
+        cp -r src/* /build/src/
     - name: Perform CodeQL analysis
       uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Fix `catastrophic error`s during CodeQL extraction by copying source files to the out-of-source build directory `build/src`.