### PR TITLE
Force arm64 architecture in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
           source-root: src
       - name: Build sources
         run: |
-          arch -arm64e cmake -S . -B build
-          arch -arm64e cmake --build build
+          cmake -S . -B build -D CMAKE_OSX_ARCHITECTURES=arm64
+          cmake --build build
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@c7f9125735019aa87cfc361530512d50ea439c71 # v3.25.1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
           source-root: src
       - name: Build sources
         run: |
-          cmake -S . -B build
-          cmake --build build
+          arch -arm64e cmake -S . -B build
+          arch -arm64e cmake --build build
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@c7f9125735019aa87cfc361530512d50ea439c71 # v3.25.1


### PR DESCRIPTION
This change specifies `arm64` as the CMake target architecture for CodeQL workflow runs to support the migration to macOS 14 (Sonoma). This is now the default image for `macos-latest` runner labels.