### PR TITLE
Add memory leak and buffer overflow/underflow detection

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -23,6 +23,26 @@
 #include "common.h"
 #include <stdio.h>
 
+#ifdef UNIT_TESTING
+extern void mock_assert(const int result, const char * const expression,
+    const char * const file, const int line);
+
+#undef assert
+#define assert(expression) \
+    mock_assert((int)(expression), #expression, __FILE__, __LINE__);
+
+extern void * _test_malloc(const size_t size, const char *file, const int line);
+extern void * _test_realloc(void *ptr, const size_t size, const char *file, const int line);
+extern void * _test_calloc(const size_t number_of_elements, const size_t size,
+                   const char *file, const int line);
+extern void _test_free(void * const ptr, const char *file, const int line);
+
+#define malloc(size) _test_malloc(size, __FILE__, __LINE__)
+#define realloc(ptr, size, file, line) _test_realloc(ptr, size, __FILE__, __LINE__)
+#define calloc(num, size) _test_calloc(num, size, __FILE__, __LINE__)
+#define free(ptr) _test_free(ptr, __FILE__, __LINE__)
+#endif
+
 static const char *
 flog_error_map[] = {
     [FLOG_ERROR_NONE]   = "none",

--- a/src/common.c
+++ b/src/common.c
@@ -24,23 +24,7 @@
 #include <stdio.h>
 
 #ifdef UNIT_TESTING
-extern void mock_assert(const int result, const char * const expression,
-    const char * const file, const int line);
-
-#undef assert
-#define assert(expression) \
-    mock_assert((int)(expression), #expression, __FILE__, __LINE__);
-
-extern void * _test_malloc(const size_t size, const char *file, const int line);
-extern void * _test_realloc(void *ptr, const size_t size, const char *file, const int line);
-extern void * _test_calloc(const size_t number_of_elements, const size_t size,
-                   const char *file, const int line);
-extern void _test_free(void * const ptr, const char *file, const int line);
-
-#define malloc(size) _test_malloc(size, __FILE__, __LINE__)
-#define realloc(ptr, size, file, line) _test_realloc(ptr, size, __FILE__, __LINE__)
-#define calloc(num, size) _test_calloc(num, size, __FILE__, __LINE__)
-#define free(ptr) _test_free(ptr, __FILE__, __LINE__)
+#include "testing.h"
 #endif
 
 static const char *

--- a/src/config.c
+++ b/src/config.c
@@ -32,12 +32,22 @@
 #include <unistd.h>
 
 #ifdef UNIT_TESTING
-extern void mock_assert(const int result, const char* const expression,
+extern void mock_assert(const int result, const char * const expression,
     const char * const file, const int line);
 
 #undef assert
 #define assert(expression) \
     mock_assert((int)(expression), #expression, __FILE__, __LINE__);
+
+extern void * _test_malloc(const size_t size, const char *file, const int line);
+extern void * _test_realloc(void *ptr, const size_t size, const char *file, const int line);
+extern void * _test_calloc(const size_t number_of_elements, const size_t size,
+                   const char *file, const int line);
+extern void _test_free(void * const ptr, const char *file, const int line);
+
+#define malloc(size) _test_malloc(size, __FILE__, __LINE__)
+#define calloc(num, size) _test_calloc(num, size, __FILE__, __LINE__)
+#define free(ptr) _test_free(ptr, __FILE__, __LINE__)
 #endif
 
 const int subsystem_len = 257;
@@ -90,7 +100,7 @@ flog_config_new(int argc, char *argv[], FlogError *error) {
     poptReadDefaultConfig(context, 0);
 
     int option;
-    while ((option = poptGetNextOpt(context)) >= 0) {
+    while ((option = poptGetNextOpt(context)) > 0) {
         char *option_argument = poptGetOptArg(context);
 
         switch (option) {
@@ -129,8 +139,6 @@ flog_config_new(int argc, char *argv[], FlogError *error) {
                 flog_config_set_message_type(config, MSG_PRIVATE);
                 break;
         }
-
-        free(option_argument);
     }
 
     if (option < -1) {

--- a/src/config.c
+++ b/src/config.c
@@ -32,23 +32,7 @@
 #include <unistd.h>
 
 #ifdef UNIT_TESTING
-extern void mock_assert(const int result, const char * const expression,
-    const char * const file, const int line);
-
-#undef assert
-#define assert(expression) \
-    mock_assert((int)(expression), #expression, __FILE__, __LINE__);
-
-extern void * _test_malloc(const size_t size, const char *file, const int line);
-extern void * _test_realloc(void *ptr, const size_t size, const char *file, const int line);
-extern void * _test_calloc(const size_t number_of_elements, const size_t size,
-                   const char *file, const int line);
-extern void _test_free(void * const ptr, const char *file, const int line);
-
-#define malloc(size) _test_malloc(size, __FILE__, __LINE__)
-#define realloc(ptr, size, file, line) _test_realloc(ptr, size, __FILE__, __LINE__)
-#define calloc(num, size) _test_calloc(num, size, __FILE__, __LINE__)
-#define free(ptr) _test_free(ptr, __FILE__, __LINE__)
+#include "testing.h"
 #endif
 
 const int subsystem_len = 257;

--- a/src/config.c
+++ b/src/config.c
@@ -46,6 +46,7 @@ extern void * _test_calloc(const size_t number_of_elements, const size_t size,
 extern void _test_free(void * const ptr, const char *file, const int line);
 
 #define malloc(size) _test_malloc(size, __FILE__, __LINE__)
+#define realloc(ptr, size, file, line) _test_realloc(ptr, size, __FILE__, __LINE__)
 #define calloc(num, size) _test_calloc(num, size, __FILE__, __LINE__)
 #define free(ptr) _test_free(ptr, __FILE__, __LINE__)
 #endif

--- a/src/flog.c
+++ b/src/flog.c
@@ -29,23 +29,7 @@
 #include "config.h"
 
 #ifdef UNIT_TESTING
-extern void mock_assert(const int result, const char * const expression,
-    const char * const file, const int line);
-
-#undef assert
-#define assert(expression) \
-    mock_assert((int)(expression), #expression, __FILE__, __LINE__);
-
-extern void * _test_malloc(const size_t size, const char *file, const int line);
-extern void * _test_realloc(void *ptr, const size_t size, const char *file, const int line);
-extern void * _test_calloc(const size_t number_of_elements, const size_t size,
-                   const char *file, const int line);
-extern void _test_free(void * const ptr, const char *file, const int line);
-
-#define malloc(size) _test_malloc(size, __FILE__, __LINE__)
-#define realloc(ptr, size, file, line) _test_realloc(ptr, size, __FILE__, __LINE__)
-#define calloc(num, size) _test_calloc(num, size, __FILE__, __LINE__)
-#define free(ptr) _test_free(ptr, __FILE__, __LINE__)
+#include "testing.h"
 #endif
 
 #define OS_LOG_FORMAT_PUBLIC "%{public}s"

--- a/src/flog.c
+++ b/src/flog.c
@@ -29,12 +29,22 @@
 #include "config.h"
 
 #ifdef UNIT_TESTING
-extern void mock_assert(const int result, const char* const expression,
-                        const char * const file, const int line);
+extern void mock_assert(const int result, const char * const expression,
+    const char * const file, const int line);
 
 #undef assert
 #define assert(expression) \
     mock_assert((int)(expression), #expression, __FILE__, __LINE__);
+
+extern void * _test_malloc(const size_t size, const char *file, const int line);
+extern void * _test_realloc(void *ptr, const size_t size, const char *file, const int line);
+extern void * _test_calloc(const size_t number_of_elements, const size_t size,
+                   const char *file, const int line);
+extern void _test_free(void * const ptr, const char *file, const int line);
+
+#define malloc(size) _test_malloc(size, __FILE__, __LINE__)
+#define calloc(num, size) _test_calloc(num, size, __FILE__, __LINE__)
+#define free(ptr) _test_free(ptr, __FILE__, __LINE__)
 #endif
 
 #define OS_LOG_FORMAT_PUBLIC "%{public}s"

--- a/src/flog.c
+++ b/src/flog.c
@@ -43,6 +43,7 @@ extern void * _test_calloc(const size_t number_of_elements, const size_t size,
 extern void _test_free(void * const ptr, const char *file, const int line);
 
 #define malloc(size) _test_malloc(size, __FILE__, __LINE__)
+#define realloc(ptr, size, file, line) _test_realloc(ptr, size, __FILE__, __LINE__)
 #define calloc(num, size) _test_calloc(num, size, __FILE__, __LINE__)
 #define free(ptr) _test_free(ptr, __FILE__, __LINE__)
 #endif

--- a/src/testing.h
+++ b/src/testing.h
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+
+extern void mock_assert(const int result, const char * const expression,
+    const char * const file, const int line);
+
+#undef assert
+#define assert(expression) \
+    mock_assert((int)(expression), #expression, __FILE__, __LINE__);
+
+extern void * _test_malloc(const size_t size, const char *file, const int line);
+extern void * _test_realloc(void *ptr, const size_t size, const char *file, const int line);
+extern void * _test_calloc(const size_t number_of_elements, const size_t size,
+                   const char *file, const int line);
+extern void _test_free(void * const ptr, const char *file, const int line);
+
+#define malloc(size) _test_malloc(size, __FILE__, __LINE__)
+#define realloc(ptr, size, file, line) _test_realloc(ptr, size, __FILE__, __LINE__)
+#define calloc(num, size) _test_calloc(num, size, __FILE__, __LINE__)
+#define free(ptr) _test_free(ptr, __FILE__, __LINE__)


### PR DESCRIPTION
Add memory leak and buffer overflow/underflow detection. Also removes an unnecessary `while` loop iteration when parsing command-line arguments and  a `free()` call that attempts to deallocate strings belonging to `argv[]`.

> [!NOTE]
> `FlogCli` unit tests will be added [at a later date](https://github.com/marcransome/flog/issues/74).